### PR TITLE
new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Change Simple Cache
 
 
+## [1.0.5] - 2025
+
+### Added
+- More documentation into README
+- Added the `setExtraChars` method to **PSR16** Adapter in order to adapt the key validation to your needs 
+- Added the `setMaxKeyLenght` method to **PSR16** Adapter in order to modify key check for use keys with more than 64 chars lenght
+- More tests
+
+### Changed
+- `ServiceUnavailableException` when a required library or module is not instaled
+- `DestinationUnreachableException` when a destination is not available
+- Docker test container changed to php v8.4
+
+### Fixed
+- The `PsrSimpleCacheAdapter` *has* method returns `true` when the value is null, now use the *has* method from implementation comparing `null !== null`
+
+
 ## [1.0.4] - 2024-12-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # SimpleCache
 
 ## Description
+
 A small collection of read/write functions for multiples cache systems
 
 ## Install
+
 ```bash
 composer require juanchosl/simplecache
 ```
@@ -14,9 +16,9 @@ From faster to slower
 
 - Process: It's only valid for current request execution
 - Session: Only valid for a current user session
-- Memcached: If Memcached service is available
-- Memcache: If Memcached service is available
-- Redis: If Redis service is available
+- Memcached: If Memcached service is available and Memcached library is installed
+- Redis: If Redis service is available and Redis library is installed
+- Memcache: If Memcached service is available and Memcache library is installed
 - File: The most compatible system, file into filesystem, but slower
 
 ## How use it
@@ -24,65 +26,121 @@ From faster to slower
 ### Use directly one of the available libs
 
 #### For create a cache instance
+
 ```php
 use JuanchoSL\SimpleCache\Repositories\ProcessCache;
 
 $cache = new ProcessCache($_ENV['CACHE_ENVIRONMENT']);
+//The max time to expire is 30 days if you do not set a time
+$cache->setMaxTtl(3600 * 24);
 ```
+
 #### For write a cache index
-The max time to expire is 30 days if you do not set a time
+
+Set into `$cache_key` the `$value`, valid for `$ttl` seconds or default TTL if you don not pass a value
+
 ```php
 $result = $cache->set(string $cache_key, mixed $value, int $ttl = 0);
 ```
+
 #### For read a cache index
+
+Read from cache the contents of `$cache_key` and return his value or `$default` if it not exists or it is not valid
+
 ```php
-$cache_value = $cache->get(string $cache_key);
+$cache_value = $cache->get(string $cache_key, $default = null);
 ```
+
 #### For delete a cache index
+
+Delete from cache the value with `$cache_key`
+
 ```php
 $result = $cache->delete(string $cache_key);
 ```
+
+#### For write multiple cache indexes
+
+Set into `$cache_key` the `$values`, an iterable containing a list of `$cache_key => $value` pairs, valid for `$ttl` seconds or default TTL if you don not pass a value
+
+```php
+$result = $cache->setMultiple(iterable $values, int $ttl = 0);
+```
+
+#### For read multiple cache indexes
+
+Read from cache the contents of `$cache_keys` and return a list of `$key => $value` pairs. Missed keys has the `$default` value
+
+```php
+$cache_value = $cache->getMultiple(iterable $cache_keys, $default = null);
+```
+
+#### For delete a cache index
+
+Delete from cache the values from the `$cache_keys` list
+
+```php
+$result = $cache->deleteMultiple(iterable $cache_keys);
+```
+
 #### For replace a cache index
+
+Replace into cache the value with `$cache_key` with the `$new_value` without change his expiration time
+
 ```php
 $result = $cache->replace(string $cache_key, mixed $new_value);
 ```
+
 #### For change the time to live of cache index
+
+Change the expiration time of `$cache_key` with the new one passed as `$new_ttl`
+
 ```php
 $result = $cache->touch(string $cache_key, int $new_ttl);
 ```
+
 #### For increment a cache index numeric value
+
+Increments the value into `$cache_key` adding `$numeric_increment` to his value. If not exists it is created.
+
 ```php
-$result = $cache->increment(string $cache_key, int $numeric_increment, int $stating_value_if_not_exists = 0, int $ttl_if_not_exists = $max_ttl);
+$result = $cache->increment(string $cache_key, int|float $numeric_increment, int $ttl_if_not_exists = $max_ttl);
 ```
+
 #### For decrement a cache index numeric value
+
+Decrements the value into `$cache_key` subtracting `$numeric_decrement` to his value. If not exists it is created.
+
 ```php
-$result = $cache->decrement(string $cache_key, int $numeric_decrement, int $stating_value_if_not_exists = 0, int $ttl_if_not_exists = $max_ttl);
+$result = $cache->decrement(string $cache_key, int|float $numeric_decrement, int $ttl_if_not_exists = $max_ttl);
+```
+
+#### For check if the cache contains a `$cache_key`
+
+Check if key exists, is not recommended, because can be return true and just another script can remove it
+
+```php
+$result = $cache->has(string $cache_key);
+```
+
+#### For clear all cache indexes
+
+Remove all data from cache
+
+```php
+$result = $cache->clear();
 ```
 
 ### Use the provided adapter for use with compatibility with PSR-16 Simple-Cache
 
 #### Create a cache instance
+
+After create a Cache Instance, you can use it with the provided PsrSimpleCacheAdapter in order to work conform the PSR-16 https://www.php-fig.org/psr/psr-16/
+
 ```php
 use JuanchoSL\SimpleCache\Repositories\ProcessCache;
 use JuanchoSL\SimpleCache\Adapters\PsrSimpleCacheAdapter;
 
 $lib = new ProcessCache($_ENV['CACHE_ENVIRONMENT']);
 $cache = new PsrSimpleCacheAdapter($lib);
-```
-#### write a cache index
-The max time to expire is 30 days if you do not set a time
-```php
-$result = $cache->set(string $cache_key, mixed $value, int $ttl = 0);
-```
-#### check availability for a cache index
-```php
-$result = $cache->has(string $cache_key);
-```
-#### read a cache index
-```php
-$cache_value = $cache->get(string $cache_key);
-```
-#### delete a cache index
-```php
-$result = $cache->delete(string $cache_key);
 ```

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
             "homepage": "https://github.com/JuanchoSL/"
         }
     ],
+    "suggest": {
+        "ext-redis": "*",
+        "ext-memcache": "*",
+        "ext-memcached": "*"
+    },
     "require": {
         "php": "^7.2 || ^8.0",
         "psr/log": "3.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -492,16 +492,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.3.1",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
-                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
@@ -544,9 +544,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
-            "time": "2024-10-08T18:51:32+00:00"
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -668,16 +668,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.12",
+            "version": "1.12.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0"
+                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
-                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e73868f809e68fff33be961ad4946e2e43ec9e38",
+                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38",
                 "shasum": ""
             },
             "require": {
@@ -722,7 +722,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-28T22:13:23+00:00"
+            "time": "2024-12-31T07:26:13+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -668,16 +668,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.14",
+            "version": "1.12.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38"
+                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e73868f809e68fff33be961ad4946e2e43ec9e38",
-                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e0bb5cb78545aae631220735aa706eac633a6be9",
+                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9",
                 "shasum": ""
             },
             "require": {
@@ -722,7 +722,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-31T07:26:13+00:00"
+            "time": "2025-01-21T14:50:05+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Adapters/PsrSimpleCacheAdapter.php
+++ b/src/Adapters/PsrSimpleCacheAdapter.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Adapters;
 
+use JuanchoSL\Exceptions\PreconditionFailedException;
 use JuanchoSL\Validators\Types\Strings\StringValidations;
 use Psr\SimpleCache\CacheInterface;
 
 class PsrSimpleCacheAdapter implements CacheInterface
 {
     private CacheInterface $cache;
+
+    protected string $chars = 'a-zA-Z0-9_.';
+    protected int $max_lenght = 64;
+    protected string $extra_chars = '';
 
     public static function getInstance(CacheInterface $cache): CacheInterface
     {
@@ -21,10 +26,27 @@ class PsrSimpleCacheAdapter implements CacheInterface
         $this->cache = $cache;
     }
 
+    public function getPattern(): string
+    {
+        return "/^[{$this->chars}{$this->extra_chars}]{1,{$this->max_lenght}}+\$/";//$this->pattern;
+    }
+
+    public function setExtraChars(string $extra_chars): void
+    {
+        $this->extra_chars = $extra_chars;
+    }
+    public function setMaxKeyLenght(int $max_lenght): void
+    {
+        if ($max_lenght < 64) {
+            throw new PreconditionFailedException("The max lenght needs to be 64 or bigger");
+        }
+        $this->max_lenght = $max_lenght;
+    }
+
     public function has(string $key): bool
     {
         $this->checkKey($key);
-        return ($this->cache->get($key) !== false);
+        return $this->cache->has($key);
     }
 
     public function clear(): bool
@@ -85,7 +107,7 @@ class PsrSimpleCacheAdapter implements CacheInterface
     }
     protected function checkKey(string $key)
     {
-        if (!(new StringValidations)->isNotEmpty()->isLengthLessOrEqualsThan(64)->isRegex('/^[a-zA-Z0-9_.]+$/')->getResult($key)) {
+        if (!(new StringValidations)->isNotEmpty()->isRegex($this->getPattern())->getResult($key)) {
             throw new \InvalidArgumentException("The key '{$key}' is not valid");
         }
         return true;

--- a/src/Adapters/PsrSimpleCacheAdapter.php
+++ b/src/Adapters/PsrSimpleCacheAdapter.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Adapters;
 

--- a/src/Contracts/SimpleCacheInterface.php
+++ b/src/Contracts/SimpleCacheInterface.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Contracts;
 

--- a/src/Enums/Engines.php
+++ b/src/Enums/Engines.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Enums;
 

--- a/src/Factories/EngineFactory.php
+++ b/src/Factories/EngineFactory.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Factories;
 

--- a/src/Repositories/AbstractCache.php
+++ b/src/Repositories/AbstractCache.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerAwareTrait;
 abstract class AbstractCache implements SimpleCacheInterface
 {
 
-    use LoggerAwareTrait;
+    use CommonTrait, LoggerAwareTrait;
 
     protected bool $debug = false;
 

--- a/src/Repositories/AbstractCache.php
+++ b/src/Repositories/AbstractCache.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Repositories;
 

--- a/src/Repositories/CommonTrait.php
+++ b/src/Repositories/CommonTrait.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Repositories;
 

--- a/src/Repositories/FileCache.php
+++ b/src/Repositories/FileCache.php
@@ -1,16 +1,13 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Repositories;
 
+use JuanchoSL\Exceptions\DestinationUnreachableException;
 use JuanchoSL\Validators\Types\Integers\IntegerValidation;
 use JuanchoSL\Validators\Types\Strings\StringValidations;
 
 class FileCache extends AbstractCache
 {
-
-    use CommonTrait;
 
     protected string $cache_dir;
 
@@ -19,7 +16,7 @@ class FileCache extends AbstractCache
         $this->cache_dir = rtrim($host, DIRECTORY_SEPARATOR);
         if (!file_exists($this->cache_dir)) {
             if (!mkdir($this->cache_dir, 0777, true)) {
-                $exception = new \Exception("Can not connect to the required server");
+                $exception = new DestinationUnreachableException("Can not connect to the required destiny");
                 $this->log($exception, 'error', [
                     'exception' => $exception,
                     'credentials' => [
@@ -46,7 +43,6 @@ class FileCache extends AbstractCache
                         'ttl' => $data_unserialized['ttl'],
                         'data' => $data_unserialized['data']
                     ];
-                    //if (is_string($data_unserialized['data']) && $this->isSerialized($data_unserialized['data'])) {
                     if ((new StringValidations)->is()->isNotEmpty()->isSerialized()->getResult($data_unserialized['data'])) {
                         $response['data'] = unserialize($data_unserialized['data']);
                     }

--- a/src/Repositories/MemCache.php
+++ b/src/Repositories/MemCache.php
@@ -1,13 +1,13 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Repositories;
-use JuanchoSL\Exceptions\PreconditionRequiredException;
+
+use JuanchoSL\Exceptions\DestinationUnreachableException;
+use JuanchoSL\Exceptions\ServiceUnavailableException;
 
 class MemCache extends AbstractCache
 {
-    use CommonTrait;
+
     private \Memcache $server;
     private string $host;
     private int $port;
@@ -17,7 +17,7 @@ class MemCache extends AbstractCache
     public function __construct(string $host)
     {
         if (!extension_loaded('memcache')) {
-            throw new PreconditionRequiredException("The extension Memcache is not available");
+            throw new ServiceUnavailableException("The extension Memcache is not available");
         }
         if (strpos($host, ':') !== false) {
             list($this->host, $port) = explode(':', $host);
@@ -28,7 +28,7 @@ class MemCache extends AbstractCache
         }
         $this->server = new \Memcache();
         if (!$this->server->connect($this->host, $this->port)) {
-            $exception = new \Exception("Can not connect to the required server");
+            $exception = new DestinationUnreachableException("Can not connect to the required destiny");
             $this->log($exception, 'error', [
                 'exception' => $exception,
                 'credentials' => [

--- a/src/Repositories/MemCached.php
+++ b/src/Repositories/MemCached.php
@@ -1,13 +1,13 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Repositories;
-use JuanchoSL\Exceptions\PreconditionRequiredException;
+
+use JuanchoSL\Exceptions\DestinationUnreachableException;
+use JuanchoSL\Exceptions\ServiceUnavailableException;
 
 class MemCached extends AbstractCache
 {
-    use CommonTrait;
+
     private \Memcached $server;
     private string $host;
     private int $port;
@@ -17,7 +17,7 @@ class MemCached extends AbstractCache
     public function __construct(string $host)
     {
         if (!extension_loaded('memcached')) {
-            throw new PreconditionRequiredException("The extension Memcached is not available");
+            throw new ServiceUnavailableException("The extension Memcached is not available");
         }
         if (strpos($host, ':') !== false) {
             list($this->host, $port) = explode(':', $host);
@@ -28,7 +28,7 @@ class MemCached extends AbstractCache
         }
         $this->server = new \Memcached();
         if (!$this->server->addServer($this->host, $this->port)) {
-            $exception = new \Exception("Can not connect to the required server");
+            $exception = new DestinationUnreachableException("Can not connect to the required destiny");
             $this->log($exception, 'error', [
                 'exception' => $exception,
                 'credentials' => [
@@ -154,10 +154,6 @@ class MemCached extends AbstractCache
         }
         return false;
     }
-    public function __destruct()
-    {
-        $this->server->quit();
-    }
 
     public function setMultiple(iterable $values, \DateInterval|null|int $ttl = null): bool
     {
@@ -189,5 +185,10 @@ class MemCached extends AbstractCache
             }
         }
         return $response;
+    }
+
+    public function __destruct()
+    {
+        $this->server->quit();
     }
 }

--- a/src/Repositories/ProcessCache.php
+++ b/src/Repositories/ProcessCache.php
@@ -1,12 +1,12 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Repositories;
 
+use JuanchoSL\Exceptions\DestinationUnreachableException;
+
 class ProcessCache extends AbstractCache
 {
-    use CommonTrait;
+
     /**
      * @var array<string, array<string, array<string, mixed>>> $cache
      */
@@ -18,7 +18,7 @@ class ProcessCache extends AbstractCache
         $this->host_name = $index;
         static::$cache[$this->host_name] = array();
         if (!isset(static::$cache[$this->host_name])) {
-            $exception = new \Exception("Can not connect to the required server");
+            $exception = new DestinationUnreachableException("Can not connect to the required destiny");
             $this->log($exception, 'error', [
                 'exception' => $exception,
                 'credentials' => [
@@ -128,5 +128,14 @@ class ProcessCache extends AbstractCache
             }
         }
         return false;
+    }
+
+    public function deleteMultiple(iterable $keys): bool
+    {
+        $result = array_diff_key(static::$cache[$this->host_name], array_fill_keys($keys, null));
+        $counter = count(static::$cache[$this->host_name]) - count($result);
+        $this->log("Some keys are going to be deleted", 'info', ['keys' => $keys, 'method' => __FUNCTION__, 'result' => $counter]);
+        static::$cache[$this->host_name] = $result;
+        return $counter == count($keys);
     }
 }

--- a/src/Repositories/RedisCache.php
+++ b/src/Repositories/RedisCache.php
@@ -67,17 +67,6 @@ class RedisCache extends AbstractCache
     public function delete(string $key): bool
     {
         return $this->deleteMultiple([$key]);
-/*
-        if (method_exists($this->server, 'del')) {
-            $result = $this->server->del($key);
-        } elseif (method_exists($this->server, 'delete')) {
-            $result = $this->server->delete($key);
-        } elseif (method_exists($this->server, 'unlink')) {
-            $result = $this->server->unlink($key);
-        }
-        $result = (isset($result) && $result !== false);
-        $this->log("The key {key} is going to delete", 'info', ['key' => $key, 'method' => __FUNCTION__, 'result' => intval($result)]);
-        return $result;*/
     }
     
     public function deleteMultiple(iterable $keys): bool

--- a/src/Repositories/RedisCache.php
+++ b/src/Repositories/RedisCache.php
@@ -1,15 +1,13 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Repositories;
-use JuanchoSL\Exceptions\PreconditionRequiredException;
+
+use JuanchoSL\Exceptions\DestinationUnreachableException;
+use JuanchoSL\Exceptions\ServiceUnavailableException;
 use JuanchoSL\Validators\Types\Strings\StringValidations;
 
 class RedisCache extends AbstractCache
 {
-
-    use CommonTrait;
 
     private \Redis $server;
     private string $host;
@@ -20,7 +18,7 @@ class RedisCache extends AbstractCache
     public function __construct(string $host)
     {
         if (!extension_loaded('redis')) {
-            throw new PreconditionRequiredException("The extension Redis is not available");
+            throw new ServiceUnavailableException("The extension Redis is not available");
         }
         if (strpos($host, ':') !== false) {
             list($this->host, $port) = explode(':', $host);
@@ -31,7 +29,7 @@ class RedisCache extends AbstractCache
         }
         $this->server = new \Redis();
         if (!$this->server->connect($this->host, $this->port)) {
-            $exception = new \Exception("Can not connect to the required server");
+            $exception = new DestinationUnreachableException("Can not connect to the required destiny");
             $this->log($exception, 'error', [
                 'exception' => $exception,
                 'credentials' => [
@@ -41,7 +39,6 @@ class RedisCache extends AbstractCache
             ]);
             throw $exception;
         }
-        //$this->server = new \Redis(['host' => $this->host, 'port' => (int) $this->port]);
     }
 
     public function get(string $key, mixed $default = null): mixed
@@ -49,7 +46,6 @@ class RedisCache extends AbstractCache
         if ($this->server->exists($key)) {
             $value = $this->server->get($key);
             if ((new StringValidations)->is()->isNotEmpty()->isSerialized()->getResult($value)) {
-            //if (!empty($value) && is_string($value) && $this->isSerialized($value)) {
                 $value = unserialize($value);
             }
             return $value;
@@ -70,6 +66,8 @@ class RedisCache extends AbstractCache
 
     public function delete(string $key): bool
     {
+        return $this->deleteMultiple([$key]);
+/*
         if (method_exists($this->server, 'del')) {
             $result = $this->server->del($key);
         } elseif (method_exists($this->server, 'delete')) {
@@ -79,6 +77,20 @@ class RedisCache extends AbstractCache
         }
         $result = (isset($result) && $result !== false);
         $this->log("The key {key} is going to delete", 'info', ['key' => $key, 'method' => __FUNCTION__, 'result' => intval($result)]);
+        return $result;*/
+    }
+    
+    public function deleteMultiple(iterable $keys): bool
+    {
+        if (method_exists($this->server, 'del')) {
+            $result = $this->server->del($keys);
+        } elseif (method_exists($this->server, 'delete')) {
+            $result = $this->server->delete($keys);
+        } elseif (method_exists($this->server, 'unlink')) {
+            $result = $this->server->unlink($keys);
+        }
+        $result = (isset($result) && $result !== false);
+        $this->log("Some keys are going to be deleted", 'info', ['keys' => $keys, 'method' => __FUNCTION__, 'result' => intval($result)]);
         return $result;
     }
 
@@ -124,19 +136,8 @@ class RedisCache extends AbstractCache
     public function increment(string $key, int|float $increment = 1, \DateInterval|null|int $ttl = null): int|float|bool
     {
         return (is_float($increment)) ? $this->server->incrByFloat($key, $increment) : $this->server->incrBy($key, $increment);
-        /*
-        if (is_float($increment)) {
-            if (!is_numeric($value = $this->get($key))) {
-                if (!$this->set($key, $default_value, $ttl)) {
-                    return false;
-                }
-                $value = $default_value;
-            }
-            $new_value = $value + $increment;
-            return $this->replace($key, $new_value) ? $new_value : false;
-        }
-        */
     }
+
     public function decrement(string $key, int|float $decrement = 1, \DateInterval|null|int $ttl = null): int|float|bool
     {
         $value = $this->get($key);

--- a/src/Repositories/SessionCache.php
+++ b/src/Repositories/SessionCache.php
@@ -1,12 +1,11 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace JuanchoSL\SimpleCache\Repositories;
 
+use JuanchoSL\Exceptions\DestinationUnreachableException;
+
 class SessionCache extends AbstractCache
 {
-    use CommonTrait;
     protected string $host_name = 'session_cache';
 
     public function __construct(string $index)
@@ -18,7 +17,7 @@ class SessionCache extends AbstractCache
             $_SESSION[$this->host_name] = array();
         }
         if (!isset($_SESSION[$this->host_name])) {
-            $exception = new \Exception("Can not connect to the required server");
+            $exception = new DestinationUnreachableException("Can not connect to the required destiny");
             $this->log($exception, 'error', [
                 'exception' => $exception,
                 'credentials' => [
@@ -129,5 +128,15 @@ class SessionCache extends AbstractCache
             }
         }
         return false;
+    }
+
+
+    public function deleteMultiple(iterable $keys): bool
+    {
+        $result = array_diff_key($_SESSION[$this->host_name], array_fill_keys($keys, null));
+        $counter = count($_SESSION[$this->host_name]) - count($result);
+        $this->log("Some keys are going to be deleted", 'info', ['keys' => $keys, 'method' => __FUNCTION__, 'result' => $counter]);
+        $_SESSION[$this->host_name] = $result;
+        return $counter == count($keys);
     }
 }

--- a/tests/Functional/SimpleCacheTest.php
+++ b/tests/Functional/SimpleCacheTest.php
@@ -3,6 +3,7 @@
 namespace JuanchoSL\SimpleCache\Tests\Functional;
 
 use DateInterval;
+use JuanchoSL\Exceptions\PreconditionFailedException;
 use JuanchoSL\SimpleCache\Adapters\PsrSimpleCacheAdapter;
 use JuanchoSL\SimpleCache\Enums\Engines;
 use JuanchoSL\SimpleCache\Factories\EngineFactory;
@@ -180,5 +181,34 @@ class SimpleCacheTest extends TestCase
         $keys = ["a", "b", "c"];
         $this->assertTrue($cache->deleteMultiple($keys));
         $cache->clear();
+    }
+
+    /**
+     * @dataProvider providerLoginData
+     */
+    public function testInvalidKey($cache)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $cache->set("algo@", 'some data', 1);
+    }
+    /**
+     * @dataProvider providerLoginData
+     */
+    public function testValidKey($cache)
+    {
+        $cache->setExtraChars('@');
+        //echo $cache->getPattern();exit;
+        $cache->set("algo@", 'some data', 10);
+        $result = $cache->get("algo@");
+        $this->assertEquals('some data', $result);
+    }
+
+    /**
+     * @dataProvider providerLoginData
+     */
+    public function testInvalidKeyLenght($cache)
+    {
+        $this->expectException(PreconditionFailedException::class);
+        $cache->setMaxKeyLenght(25);
     }
 }

--- a/var/docker/php/Dockerfile
+++ b/var/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.4-fpm
 
 RUN apt-get update && apt-get install -y git zip libmemcached-dev zlib1g-dev libssl-dev
 
@@ -10,16 +10,8 @@ COPY composer.json .
 COPY ./vendor ./vendor
 
 RUN php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer
-#RUN composer update
-
-RUN git config --global user.email \'JuanchoSL@hotmail.com\'
-RUN git config --global user.name \'Juan Sánchez\'
-
-#COPY var/docker/php/conf.d/php.ini /usr/local/etc/php/php.ini
 
 RUN pecl install xdebug
-#COPY var/docker/php/conf.d/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
-
 
 # install the memcached extension
 RUN yes '' | pecl install -f memcached && docker-php-ext-enable memcached


### PR DESCRIPTION
## [1.0.5] - 2025

### Added
- More documentation into README
- Added the `setExtraChars` method to **PSR16** Adapter in order to adapt the key validation to your needs 
- Added the `setMaxKeyLenght` method to **PSR16** Adapter in order to modify key check for use keys with more than 64 chars lenght
- More tests

### Changed
- `ServiceUnavailableException` when a required library or module is not instaled
- `DestinationUnreachableException` when a destination is not available
- Docker test container changed to php v8.4

### Fixed
- The `PsrSimpleCacheAdapter` *has* method returns `true` when the value is null, now use the *has* method from implementation comparing `null !== null`

